### PR TITLE
fix: update outputs and fix cluster IAM role reference

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   terraform-ci:
+    name: Terraform CI
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_neptune_cluster" "this" {
   neptune_subnet_group_name            = try(aws_neptune_subnet_group.this[0].name, null)
   kms_key_arn                          = try(var.kms_key_arn, null)
   iam_database_authentication_enabled  = var.iam_database_authentication_enabled
-  iam_roles                            = try([module.iam_role_neptune.iam_role_arn], var.iam_roles)
+  iam_roles                            = try([aws_iam_role.this[0].arn], var.iam_roles)
   availability_zones                   = try(var.availability_zones, null)
   copy_tags_to_snapshot                = try(var.copy_tags_to_snapshot, null)
   final_snapshot_identifier            = try(var.final_snapshot_identifier, null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,9 +23,9 @@ output "neptune_cluster_resource_id" {
   value       = try(aws_neptune_cluster.this[0].cluster_resource_id, null)
 }
 
-output "neptune_cluster_snapshot_arn" {
-  description = "The Amazon Resource Name (ARN) for the DB Cluster Snapshot"
-  value       = try(aws_neptune_cluster_snapshot.this[0].arn, null)
+output "neptune_cluster_snapshot_identifier" {
+  description = "The Identifier for the DB Cluster Snapshot"
+  value       = try(aws_neptune_cluster_snapshot.this[0].db_cluster_snapshot_identifier, null)
 }
 
 output "neptune_iam_role_arn" {
@@ -33,9 +33,14 @@ output "neptune_iam_role_arn" {
   value       = try(aws_iam_role.this[0].arn, null)
 }
 
-output "neptune_instance_id" {
-  description = "ID of the Neptune cluster instance"
-  value       = try(aws_neptune_cluster_instance.this[0].id, null)
+output "neptune_primary_instance_id" {
+  description = "ID of the primary Neptune cluster instance"
+  value       = try(aws_neptune_cluster_instance.primary[0].id, null)
+}
+
+output "neptune_read_replica_ids" {
+  description = "IDs of the Neptune read replica instances"
+  value       = try(aws_neptune_cluster_instance.read_replicas[*].id, [])
 }
 
 output "neptune_parameter_group_id" {


### PR DESCRIPTION
### Fixes

- Replaced `aws_neptune_cluster_snapshot.this[0].arn` with `db_cluster_snapshot_identifier`
- Corrected references to `aws_neptune_cluster_instance` by splitting outputs for primary and read replicas
- Updated `outputs.tf` to align with the module's actual resource structure