### PR TITLE
fix: add outputs and make args optional

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -8,8 +8,13 @@ output "neptune_cluster_arn" {
   value       = try(aws_neptune_cluster.this[0].arn, null)
 }
 
+output "neptune_cluster_members" {
+  description = "List of Neptune Instances that are a part of this cluster"
+  value       = try(aws_neptune_cluster.this[0].cluster_members, null)
+}
+
 output "neptune_cluster_endpoint" {
-  description = "The endpoint of the Neptune cluster"
+  description = "The DNS endpoint of the Neptune cluster instance"
   value       = try(aws_neptune_cluster.this[0].endpoint, null)
 }
 


### PR DESCRIPTION
## Purpose

This PR enhances the robustness of resources and resource tags handling by ensuring optional variables are gracefully managed when undefined or null. Default values are applied where necessary to prevent errors during merge operations.

## Changes

- Added an additional output `neptune_cluster_members`
- Changed required variables to optional where a default value exists
- Updated tags assignments to use try for handling undefined or null tags
  - Ensures `var.tags` defaults to `{}` if not provided.
  - Handles optional tags gracefully.
- Maintains existing functionality while improving reliability in variable handling